### PR TITLE
Add Perl 5.32.0 to dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:latest
 
-LABEL version="1.9"
+LABEL version="1.10"
 LABEL maintainer="Steve Guo <steve.guo@thunes.com>"
 
 RUN apt-get update \
@@ -19,6 +19,7 @@ RUN plenv install 5.24.0 -j 20 --noman > /dev/null
 RUN plenv install 5.26.0 -j 20 --noman > /dev/null
 #RUN plenv install 5.28.0 -j 20 --noman > /dev/null
 RUN plenv install 5.30.0 -j 20 --noman > /dev/null
+RUN plenv install 5.32.0 -j 20 --noman > /dev/null
 
 RUN rm -rfv ~/.plenv/build/* && rm -rfv ~/usr/share/plenv/build/*
 
@@ -32,6 +33,10 @@ RUN eval "$(plenv init -)" && cd ~/ \
 
 RUN eval "$(plenv init -)" && cd ~/ \
     && plenv local 5.30.0 && plenv install-cpanm && plenv rehash \
+    && cpanm -n Carton && plenv rehash
+
+RUN eval "$(plenv init -)" && cd ~/ \
+    && plenv local 5.32.0 && plenv install-cpanm && plenv rehash \
     && cpanm -n Carton && plenv rehash
 
 COPY ./init.sh /init.sh


### PR DESCRIPTION
This adds in Perl 5.32.0 into the dockerfile for local dev testing.

Note that if we rebuild this as-is, this will cause an update from Ubuntu 18.04 to 20.04; do you want to pin the repo to 18.04 (or switch to CentOS 8)? I see no issues with allowing the upgrade to happen.